### PR TITLE
String is in the prelude, no reason to import it

### DIFF
--- a/busy-beaver-rust/src/main.rs
+++ b/busy-beaver-rust/src/main.rs
@@ -1,7 +1,6 @@
 
 extern crate time;
 
-use std::string::String;
 use MachineMove::*;
 
 #[derive(Copy,Clone)]


### PR DESCRIPTION
Hey there! was reading your blog earlier, checked out the code, and noticed this.

I think the reason you're still slower than C is due to the bounds checking on `[]`. Normally, this isn't an issue, but it's one thing that looks like it to me. Usually, iterators let you get away with removing them entirely, but I haven't checked it out close enough to see if you could use them instead of the indexing.
